### PR TITLE
Updated redirects to work correctly regardless of domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -165,16 +165,15 @@ from = "/cloud/"
 to = "/ui/cloud/"
 status = 301
 
-
 [[redirects]]
-from = "https://docs.prefect.io/2*"
-to = "https://docs.prefect.io/2*:splat"
+from = "/2*"
+to = "/2*:splat"
 status = 200
 force = false
 
 [[redirects]]
-from = "https://docs.prefect.io/*"
-to = "https://docs.prefect.io/latest/:splat"
+from = "/*"
+to = "/latest/:splat"
 status = 301
 
 [[headers]]

--- a/overrides/netlify/netlify.additions.toml
+++ b/overrides/netlify/netlify.additions.toml
@@ -2,13 +2,13 @@
 # prefecthq/prefect/netlify.toml
 
 [[redirects]]
-from = "https://docs.prefect.io/2*"
-to = "https://docs.prefect.io/2*:splat"
+from = "/2*"
+to = "/2*:splat"
 status = 200
 force = false
 
 [[redirects]]
-from = "https://docs.prefect.io/*"
-to = "https://docs.prefect.io/latest/:splat"
+from = "/*"
+to = "/latest/:splat"
 status = 301
 


### PR DESCRIPTION
This PR updates the Netlify redirects to work correctly regardless of whether the docs are deployed to docs.prefect.io.