### PR TITLE
Update 2.6.x version label

### DIFF
--- a/versions/versions.json
+++ b/versions/versions.json
@@ -53,7 +53,7 @@
     },
     {
         "version": "2.6",
-        "title": "2.6.x",
+        "title": "2.6.x and earlier",
         "aliases": []
     }
 ]


### PR DESCRIPTION
This PR updates the 2.6.x version selector label to '2.6.x and earlier'. 