### PR TITLE
Removed incorrect Netlify redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -101,11 +101,6 @@ to = "/integrations/contribute/"
 status = 301
 
 [[redirects]]
-from = "/tutorials/first-steps/"
-to = "/tutorials/"
-status = 301
-
-[[redirects]]
 from = "/migration-guide/"
 to = "/guides/migration-guide/"
 status = 301


### PR DESCRIPTION
This PR removes an old redirect currently preventing users from loading the `/tutorials/first-steps` docs page. 