### PR TITLE
Update build-docs.yaml by pinning mkdocs material version

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -102,7 +102,7 @@ jobs:
       env:
         MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO: ${{ secrets.MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO }}
       run: |
-        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git
+        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@dc2fd1973cbe73933f270829520bd6626510de5c \
         sudo apt-get install -y libcairo2
         
 


### PR DESCRIPTION
Builds breaking with newer version of mkdocs material. This pins to the version used in prefecthq/prefect `dc2fd1973cbe73933f270829520bd6626510de5c`