### PR TITLE
Fix branch for `mkdocs-material-insiders`

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -102,7 +102,7 @@ jobs:
       env:
         MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO: ${{ secrets.MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO }}
       run: |
-        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@main
+        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@master
         sudo apt-get install -y libcairo2
         
 


### PR DESCRIPTION
Uses `master` not `main`
