### PR TITLE
fix: invert git diff logic

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -254,7 +254,7 @@ jobs:
         rm -f ./netlify/edge-functions/*
         cp $PREFECT_SOURCE/netlify/edge-functions/* ./netlify/edge-functions/
         git add ./netlify/edge-functions
-        if git diff --quiet --cached; then
+        if ! git diff --quiet --cached; then
           git commit -m "Update Netlify edge functions"
         fi
 


### PR DESCRIPTION
We were previously committing changes only if the diff was empty, so fix the logic.