### PR TITLE
fix: load environment variables from GitHub Actions

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -128,6 +128,9 @@ jobs:
 
 
     - name: Update docs
+      env:
+        AMPLITUDE_API_KEY: ${{ vars.AMPLITUDE_API_KEY }}
+        AMPLITUDE_URL: ${{ vars.AMPLITUDE_URL }}
       run: |
         git config user.name "GitHub Actions Bot"
         git config user.email "github-actions-bot@example.com"


### PR DESCRIPTION
Load AMPLITUDE_API_KEY and AMPLITUDE_URL variables from GitHub Actions' environment variables store.