### PR TITLE
Update build-docs.yaml

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -207,7 +207,9 @@ jobs:
           # https://github.com/jimporter/mike/issues/157
           # For now, copying the latest numbered version folder to "latest"
           # so someone doesn't have to do it manually.
-          cp ./versions/"$version" ./versions/latest
+          # This attempted fix doesn't work b/c the folder isn't there yet- PR needs accepted first.
+          # cp ./versions/"$version" ./versions/latest
+          
         else
           echo "Updating previous docs version with $version."
           mike deploy --config-file ./mkdocs.insiders.yml --update-aliases --branch $branch_name --prefix=versions "$display_name"


### PR DESCRIPTION
Copying the most recent build to latest to fix the Mike image url bug doesn't work b/c the folder isn't there yet. Needs PR accepted. Reverting and will manually copy the most recent folder to latest and rename it.