### PR TITLE
indent bash output in build-docs.yaml

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -240,22 +240,22 @@ jobs:
         # Update Netlify TOML when building docs
         if [[ $version != "unreleased" ]]; then
             cat <<EOT > ./netlify.additions.toml 
-[[redirects]]
-from = "/2*"
-to = "/2*:splat"
-status = 200
-force = false
-
-[[redirects]]
-from = "/*"
-to = "/$version/:splat"
-status = 301
-
-[[redirects]]
-from = "/latest/"
-to = "/$version/"
-status = 200
-EOT
+            [[redirects]]
+            from = "/2*"
+            to = "/2*:splat"
+            status = 200
+            force = false
+            
+            [[redirects]]
+            from = "/*"
+            to = "/$version/:splat"
+            status = 301
+            
+            [[redirects]]
+            from = "/latest/"
+            to = "/$version/"
+            status = 200
+            EOT
         fi
 
         git checkout $branch_name


### PR DESCRIPTION
Not sure why it appeared to build fine in preview.