### PR TITLE
Improve redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,11 +11,6 @@ base = ""
 command = ""
 publish = "versions"
 
-[[redirects]]
-from = "/latest/concepts/incidents"
-to = "/cloud/incidents"
-status = 301
-
 
 [[redirects]]
 from = "/concepts/incidents"
@@ -434,6 +429,431 @@ status = 301
 [[redirects]]
 from = "/contributing/common-mistakes/"
 to = "/guides/troubleshooting/"
+status = 301
+
+# redirect rules match on the first rule, so to have /latest/ version 
+# also redirect, need to explicitly catch, so each of the above rules
+# is below with /latest/ prefix
+
+
+
+# redirect v1 traffic to docs-v1.prefect.io
+
+[[redirects]]
+from = "/core/*"
+to = "https://docs-v1.prefect.io/core/:splat"
+status = 301
+
+[[redirects]]
+from = "/orchestration/*"
+to = "https://docs-v1.prefect.io/orchestration/:splat"
+status = 301
+
+[[redirects]]
+from = "/api/*"
+to = "https://docs-v1.prefect.io/api/:splat"
+status = 301
+
+[[redirects]]
+from = "https://orion-docs.prefect.io/*"
+to = "https://docs.prefect.io/:splat"
+status = 301
+
+[[redirects]]
+from = "/latest/migration_guide/"
+to = "/guides/migration-guide/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/work-queues/"
+to = "/cloud/work-pools/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/work-queues/"
+to = "/concepts/work-pools/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/cloud-getting-started/"
+to = "/getting-started/quickstart/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/overview/"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/overview"
+to = "/api-ref/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/overview/"
+to = "/concepts/"
+status = 301
+
+[[redirects]]
+from = "/latest/collections/catalog/"
+to = "/integrations/"
+status = 301
+
+[[redirects]]
+from = "/latest/collections/usage/"
+to = "/integrations/usage/"
+status = 301
+
+[[redirects]]
+from = "/latest/collections/contribute/"
+to = "/integrations/contribute/"
+status = 301
+
+[[redirects]]
+from = "/latest/migration-guide/"
+to = "/guides/migration-guide/"
+status = 301
+
+[[redirects]]
+from = "/latest/recipes/contribute-recipes/"
+to = "/recipes/recipes/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/docker/"
+to = "/guides/deployment/docker/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/cloud-agent/"
+to = "/guides/deployment/aci/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/testing/"
+to = "/guides/testing/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/dask-ray-task-runners/"
+to = "/guides/dask-ray-task-runners/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/prefect/blocks/storage/"
+to = "/api-ref/prefect/blocks/filesystems/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/flow-task/"
+to = "/tutorials/first-steps/"
+status = 301
+
+[[redirects]]
+from = "/latest/integrations/catalog/"
+to = "/integrations/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/flows-and-tasks/"
+to = "/concepts/flows/"
+status = 301
+
+[[redirects]]
+from = "/latest/getting-started/overview/"
+to = "/"
+status = 301
+ 
+[[redirects]]
+from = "/latest/ui/index/"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/cloud/"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/cloud-quickstart/" 
+to = "/getting-started/quickstart/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/cloud-api-keys/"
+to = "/cloud/users/api-keys/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/cloud-local-environment/"
+to = "/cloud/connecting/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/organizations/"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/workspaces/"
+to = "/cloud/workspaces/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/service-accounts/"
+to = "/cloud/users/service-accounts/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/roles/"
+to = "/cloud/users/roles/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/sso/"
+to = "/cloud/users/sso/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/audit-log/"
+to = "/cloud/users/audit-log/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/automations/"
+to = "/concepts/automations/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/events/"
+to = "/cloud/events/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/troubleshooting/"
+to = "/cloud/connecting/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/rate-limits/"
+to = "/cloud/rate-limits/"
+status = 301
+
+[[redirects]]
+from = "/latest/cloud/overview/"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/prefect/blocks/storage/"
+to = "/api-ref/prefect/blocks/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/prefect/deployments/"
+to = "/api-ref/prefect/deployments/deployments/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorial/deployments-ux/"
+to = "/tutorial/deployments/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/blocks/"
+to = "/concepts/blocks/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/work-pools/"
+to = "/concepts/work-pools/"
+status = 301
+
+
+[[redirects]]
+from = "/latest/concepts/server/"
+to = "/host/"
+status = 301
+
+
+[[redirects]]
+from = "/latest/concepts/database/"
+to = "/host/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/notifications/"
+to = "/host/#notifications"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/notifications/"
+to = "/host/#notifications"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/work-pools/"
+to = "/concepts/work-pools/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/task-concurrency"
+to = "/concepts/tasks/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/flow-runs"
+to = "/concepts/flows/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/deployments"
+to = "/concepts/deployments/"
+status = 301
+
+[[redirects]]
+from = "/latest/ui/cloud-quickstart/"
+to = "/getting-started/quickstart/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/developing-a-new-worker-type/"
+to = "/guides/deployment/developing-a-new-worker-type/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/rest-api-overview/"
+to = "/api-ref/rest-api/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/projects/"
+to = "/concepts/deployments/"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorial/projects/"
+to = "/tutorial/deployments-ux/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/prefect/projects/"
+to = "/api-ref/prefect/deployments-ux/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/prefect/projects/"
+to = "/api-ref/prefect/deployments-ux/"
+status = 301
+
+[[redirects]]
+from = "/latest/guides/cloud-run-push-work-pools/"
+to = "/guides/deployment/push-work-pools/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/logs/"
+to = "/guides/logs/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/runtime-context/"
+to = "/guides/runtime-context/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/settings/"
+to = "/guides/settings/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/variables/"
+to = "/guides/variables/"
+status = 301
+
+[[redirects]]
+from = "/latest/cloud/webhooks/"
+to = "/guides/webhooks/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/events/"
+to = "/cloud/events/"
+status = 301
+
+[[redirects]]
+from = "/latest/cloud/automations/"
+to = "/concepts/automations/"
+status = 301
+
+[[redirects]]
+from = "/latest/host/"
+to = "/guides/host/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/deployments-ux/"
+to = "/concepts/deployments/"
+status = 301
+
+[[redirects]]
+from = "/latest/guides/deployment/helm-worker/"
+to = "/guides/deployment/kubernetes/"
+status = 301
+
+[[redirects]]
+from = "/latest/guides/deployment/docker/"
+to = "/guides/docker/"
+status = 301
+
+[[redirects]]
+from = "/latest/cloud/cloud-quickstart/"
+to = "/getting-started/quickstart/"
+status = 301
+
+[[redirects]]
+from = "/latest/cloud/organizations/*"
+to = "/cloud/"
+status = 301
+
+[[redirects]]
+from = "/latest/guides/deployment/aci/"
+to = "/guides/deployment/serverless-workers/"
+status = 301
+
+[[redirects]]
+from = "/latest/contributing/common-mistakes/"
+to = "/guides/troubleshooting/"
+status = 301
+
+[[redirects]]
+from = "/latest/concepts/incidents"
+to = "/cloud/incidents"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorial/first-steps/"
+to = "/#prefect-quickstart/"
+status = 301
+
+[[redirects]]
+from = "/latest/collections/overview/"
+to = "/integrations/catalog/"
+status = 301
+
+[[redirects]]
+from = "/latest/api-ref/orion/*"
+to = "/api-ref/server/:splat"
+status = 301
+
+[[redirects]]
+from = "/latest/tutorials/*"
+to = "/tutorial/:splat"
 status = 301
 
 [[redirects]]


### PR DESCRIPTION
A URL with `/latest/some-redirect` wasn't redirecting because netlify matches on the first redirect.

Only a url without `latest` would forward.

This PR adds rules specifying `latest` should match. This looks duplicative, but is necessary because, as the Netlify docs explain, "It’s not possible to use an asterisk as a wildcard in the middle of a path, for example /jobs/*.html. You can only use asterisks at the end of the path segment, such as /jobs/*." https://docs.netlify.com/routing/redirects/redirect-options/

This issue would only be exacerbated if we forwarded to the latest numbered version rather than 'latest".