### PR TITLE
Update build-docs.yaml pin to latest mkdocs material version

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -116,7 +116,7 @@ jobs:
       env:
         MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO: ${{ secrets.MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO }}
       run: |
-        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@706cb730a2efbc1032226af3937207223cb07e05
+        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@d7aff94f888b6f3300d32e25d37836333582e44c
         sudo apt-get install -y libcairo2
         
 


### PR DESCRIPTION
Tested locally and in Prefect main repo and merged in Prefect main repo.