### PR TITLE
Update mkdocs material pin for bug fix

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -116,7 +116,7 @@ jobs:
       env:
         MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO: ${{ secrets.MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO }}
       run: |
-        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@f90c86e90727f40683f44230330cb3d77df8572f
+        pip install git+https://oauth2:$MKDOCS_MATERIAL_INSIDERS_CONTENTS_RO@github.com/PrefectHQ/mkdocs-material-insiders.git@1471e7595c14a067031600ec18e3cc8d7964e4aa
         sudo apt-get install -y libcairo2
         
 


### PR DESCRIPTION
There was a change in Google Fonts that led to mkdocs material docs builds failing. I updated our pinned yesterday and there was a little bug found and resolved in some mkdocs material installs last night. 
https://github.com/squidfunk/mkdocs-material/releases/tag/9.5.17
![Screenshot 2024-04-02 at 11 47 02 AM](https://github.com/PrefectHQ/docs/assets/7703961/89aa9206-a3b8-48e8-87c5-21cff53f7b81)
