### PR TITLE
Update build-docs workflow to install integrations packages

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -106,7 +106,8 @@ jobs:
 
     - name: Install Prefect and dependencies
       run: |
-        pip install --upgrade pip 
+        pip install --upgrade pip
+        pip install src/integrations/*
         pip install --upgrade --upgrade-strategy eager  -e ".[dev]"
 
       working-directory: ${{ github.workspace }}/prefect_source


### PR DESCRIPTION
We need to install the integrations packages to generate documentation from their docstrings.

Follow up to https://github.com/PrefectHQ/prefect/pull/12794