### PR TITLE
Add pretend version for `prefect-shell` on install

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -105,6 +105,8 @@ jobs:
       
 
     - name: Install Prefect and dependencies
+      env: 
+        SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PREFECT_SHELL: "0.2.0"
       run: |
         pip install --upgrade pip
         pip install src/integrations/*


### PR DESCRIPTION
We clone only the most recent commit of the `prefect` repo which prevents us from determining current integrations versions when installing. That's normally fine except for the dependency that `prefect-dbt` has on `prefect-shell`. This PR adds an environment variable for a 'pretend' version of `prefect-shell` so installation runs successfully.