### PR TITLE
chore: 301 from orion-docs -> docs-2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,9 +26,8 @@ to = "https://docs-v1.prefect.io/api/:splat"
 status = 301
 
 [[redirects]]
-conditions = { Host = "orion-docs.prefect.io" }
-from = "/*"
-to = "https://docs-2.prefect.io/:splat"
+from = "https://orion-docs.prefect.io/*"
+to = "https://docs-2.prefect.io"
 status = 301
 
 # Netlify redirect rules match on the first rule,

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,14 +26,15 @@ to = "https://docs-v1.prefect.io/api/:splat"
 status = 301
 
 [[redirects]]
-from = "https://orion-docs.prefect.io/*"
-to = "https://docs.prefect.io/:splat"
+conditions = { Host = "orion-docs.prefect.io" }
+from = "/*"
+to = "https://docs-2.prefect.io/:splat"
 status = 301
 
-# Netlify redirect rules match on the first rule, 
-# so to have /latest/ version 
+# Netlify redirect rules match on the first rule,
+# so to have /latest/ version
 # also redirect. So need to explicitly catch /latest/...
-# Each of the rules below for a Prefect 2 URL redirect 
+# Each of the rules below for a Prefect 2 URL redirect
 # has a counterpart further below with /latest/ prefix
 
 
@@ -434,10 +435,10 @@ from = "/collections/overview/"
 to = "/integrations/catalog/"
 status = 301
 
-# Netlify redirect rules match on the first rule, 
-# so to have /latest/ version 
+# Netlify redirect rules match on the first rule,
+# so to have /latest/ version
 # also redirect. So need to explicitly catch /latest/...
-# Each of the above rules for a Prefect 2 URL redirect 
+# Each of the above rules for a Prefect 2 URL redirect
 # is below with /latest/ prefix
 
 [[redirects]]
@@ -916,12 +917,12 @@ Content-Security-Policy = """\
         https://api.github.com \
         https://www.google-analytics.com \
         ; \
-      font-src 
+      font-src
         https://fonts.gstatic.com \
         ; \
       frame-ancestors 'none' \
         ; \
-      frame-src 
+      frame-src
         https://www.youtube.com \
         ; \
       img-src \

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,13 +25,6 @@ from = "/api/*"
 to = "https://docs-v1.prefect.io/api/:splat"
 status = 301
 
-[[redirects]]
-conditions = { Host = "orion-docs.prefect.io" }
-from = "/*"
-to = "https://docs-2.prefect.io/:splat"
-status = 301
-force = true
-
 # Netlify redirect rules match on the first rule,
 # so to have /latest/ version
 # also redirect. So need to explicitly catch /latest/...

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,9 +26,11 @@ to = "https://docs-v1.prefect.io/api/:splat"
 status = 301
 
 [[redirects]]
-from = "https://orion-docs.prefect.io/*"
-to = "https://docs-2.prefect.io"
+conditions = { Host = "orion-docs.prefect.io" }
+from = "/*"
+to = "https://docs-2.prefect.io/:splat"
 status = 301
+force = true
 
 # Netlify redirect rules match on the first rule,
 # so to have /latest/ version

--- a/versions/_redirects
+++ b/versions/_redirects
@@ -1,0 +1,1 @@
+https://orion-docs.prefect.io/* https://docs-2.prefect.io/:splat 301!


### PR DESCRIPTION
https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects

tried it a couple of ways using netlify.toml, but only the added `_rewrites` config in the publish dir seemed to work

https://www.loom.com/share/e63273c5071948ddb6b9b89b0f88b952?from_recorder=1&focus_title=1
